### PR TITLE
feat: add new enum for compression setting

### DIFF
--- a/src/DeltaLake/DeltaCompression.cs
+++ b/src/DeltaLake/DeltaCompression.cs
@@ -1,0 +1,38 @@
+using ParquetSharp;
+
+namespace DeltaLake;
+
+public enum DeltaCompression
+{
+    Uncompressed,
+    Snappy,
+    Gzip,
+    Brotli,
+    Zstd,
+    Lz4,
+    Lz4Frame,
+    Lzo,
+    Bz2,
+    Lz4Hadoop,
+}
+
+public static class DeltaCompressionExtensions
+{
+
+    public static Compression ToParquetSharpCompression(this DeltaCompression compression) =>
+        compression switch
+        {
+            DeltaCompression.Uncompressed => Compression.Uncompressed,
+            DeltaCompression.Snappy => Compression.Snappy,
+            DeltaCompression.Gzip => Compression.Gzip,
+            DeltaCompression.Brotli => Compression.Brotli,
+            DeltaCompression.Zstd => Compression.Zstd,
+            DeltaCompression.Lz4 => Compression.Lz4,
+            DeltaCompression.Lz4Frame => Compression.Lz4Frame,
+            DeltaCompression.Lzo => Compression.Lzo,
+            DeltaCompression.Bz2 => Compression.Bz2,
+            DeltaCompression.Lz4Hadoop => Compression.Lz4Hadoop,
+            _ => throw new ArgumentOutOfRangeException(nameof(compression), compression, null)
+        };
+
+}

--- a/tests/DeltaLake.Tests/Unit/DeltaCompressionTests.cs
+++ b/tests/DeltaLake.Tests/Unit/DeltaCompressionTests.cs
@@ -1,0 +1,18 @@
+namespace DeltaLake.Tests.Unit;
+
+public class DeltaCompressionTests
+{
+    [Fact]
+    public void ToParquetSharpCompression_WithAllCompressionValues_ShouldReturnEquivalentParquetSharpCompression()
+    {
+        // Arrange
+        var expected = Enum.GetValues(typeof(ParquetSharp.Compression));
+        var sourceEnumValues = Enum.GetValues(typeof(DeltaCompression)).Cast<DeltaCompression>();
+        
+        // Act
+        var convertedEnums = sourceEnumValues.Select(i => i.ToParquetSharpCompression());
+        
+        // Assert
+        Assert.Equivalent(expected, convertedEnums);
+    }
+}


### PR DESCRIPTION
Introduce a new enum to the public API, allowing consumers to use it instead of relying on internal dependencies (ParquetSharp)

# Before 
```csharp

using DeltaLake;
using ParquetSharp;

.... 

table = new DeltaTable.Builder()
            .FromTable(table)
            .Add(data, options => { options.Compression = Compression.Brotli; })
            .Build();
```

# After 
```csharp
using DeltaLake;

.... 

table = new DeltaTable.Builder()
            .FromTable(table)
            .Add(data, options => { options.Compression = DeltaCompression.Brotli; })
            .Build();
```

Not sure about the naming, _DeltaCompression_. Didn't go with _Compression_ just to avoid confusion and collisions



