### PR TITLE
feat: add transaction delta action

### DIFF
--- a/src/DeltaLake/Protocol/DeltaAction.cs
+++ b/src/DeltaLake/Protocol/DeltaAction.cs
@@ -5,13 +5,14 @@ namespace DeltaLake.Protocol;
 
 public sealed record class DeltaAction
 {
-    public DeltaMetaData? MetaData { get; } = null;
-    public DeltaAdd? Add { get; } = null;
-    public DeltaRemove? Remove { get; } = null;
-    public DeltaProtocol? Protocol { get; } = null;
-    public JsonDocument? CommitInfo { get; } = null;
+    public DeltaMetaData? MetaData { get; }
+    public DeltaAdd? Add { get; }
+    public DeltaRemove? Remove { get; }
+    public DeltaTransaction? Txn { get; }
+    public DeltaProtocol? Protocol { get; }
+    public JsonDocument? CommitInfo { get; }
 
-    public DeltaAction(DeltaMetaData? metaData = null, DeltaAdd? add = null, DeltaRemove? remove = null, DeltaProtocol? protocol = null, JsonDocument? commitInfo = null)
+    public DeltaAction(DeltaMetaData? metaData = null, DeltaAdd? add = null, DeltaRemove? remove = null, DeltaProtocol? protocol = null, JsonDocument? commitInfo = null,  DeltaTransaction? txn = null)
     {
         int count = 0;
         if (metaData is not null) count++;
@@ -19,6 +20,7 @@ public sealed record class DeltaAction
         if (remove is not null) count++;
         if (protocol is not null) count++;
         if (commitInfo is not null) count++;
+        if (txn is not null) count++;
 
         if (count == 0) throw new ArgumentException("At least one action must be set");
         if (count != 1) throw new ArgumentException("Only one action can be set");
@@ -28,6 +30,7 @@ public sealed record class DeltaAction
         Remove = remove;
         Protocol = protocol;
         CommitInfo = commitInfo;
+        Txn = txn;
     }
 
     public static JsonSerializerOptions JsonSerializerOptions { get; } = new()
@@ -51,5 +54,4 @@ public sealed record class DeltaAction
     {
         return JsonSerializer.Serialize(this, JsonSerializerOptions);
     }
-
 }

--- a/src/DeltaLake/Protocol/DeltaTransaction.cs
+++ b/src/DeltaLake/Protocol/DeltaTransaction.cs
@@ -1,0 +1,3 @@
+namespace DeltaLake.Protocol;
+
+public record DeltaTransaction(string AppId, long Version, long? LastUpdated = null);

--- a/tests/DeltaLake.Tests/Unit/Protocol/DeltaActionTests.cs
+++ b/tests/DeltaLake.Tests/Unit/Protocol/DeltaActionTests.cs
@@ -87,6 +87,16 @@ public class DeltaActionTests
         ];
 
         yield return [
+            """{"txn":{"appId":"my-application","version":1}}""",
+            new DeltaAction(txn: new("my-application", 1))
+        ];
+
+        yield return [
+            """{"txn":{"appId":"my-application","version":1,"lastUpdated":1234}}""",
+            new DeltaAction(txn: new("my-application", 1, 1234))
+        ];
+
+        yield return [
             """{"remove":{"path":"path","dataChange":true}}""",
             new DeltaAction(remove: new("path", true))
         ];
@@ -108,4 +118,3 @@ public class DeltaActionTests
 
     }
 }
-


### PR DESCRIPTION
This PR adds the option to create [transactions ](https://github.com/ueshin/databricks-delta/blob/master/PROTOCOL.md#transaction-identifiers)when adding data to the table.


The `AddOptions` is extended with a new Transaction property.

```csharp
var appId = "4366b1f6-8029-4368-8907-ea7a615e2a79";
var version = 1;
var lastUpdated = 1716489784324;  // optional

 var table = new DeltaTable.Builder()
            .WithFileSystem(fs)
            .WithSchema(schema)
            .EnsureCreated()
            .Add(data, options => { options.Transaction = new(appId, version, lastUpdated); })
            .Build();
```
